### PR TITLE
Have physics engine run smoother

### DIFF
--- a/physics/body.go
+++ b/physics/body.go
@@ -8,12 +8,12 @@ import (
 type Body struct {
 	Name string
 
+	Mass            float32
+	MomentOfInertia sprec.Mat3
+
 	Position    sprec.Vec3
 	Orientation sprec.Quat
 	IsStatic    bool
-
-	Mass            float32
-	MomentOfInertia sprec.Mat3
 
 	Acceleration        sprec.Vec3
 	AngularAcceleration sprec.Vec3

--- a/physics/body.go
+++ b/physics/body.go
@@ -36,6 +36,7 @@ func (b *Body) Translate(offset sprec.Vec3) {
 func (b *Body) Rotate(vector sprec.Vec3) {
 	if radians := vector.Length(); sprec.Abs(radians) > radialEpsilon {
 		b.Orientation = sprec.QuatProd(sprec.RotationQuat(sprec.Radians(radians), vector), b.Orientation)
+		b.Orientation = sprec.UnitQuat(b.Orientation)
 	}
 }
 

--- a/physics/engine.go
+++ b/physics/engine.go
@@ -17,8 +17,7 @@ const (
 
 func NewEngine(step time.Duration) *Engine {
 	return &Engine{
-		step:            step,
-		accumulatedTime: 0,
+		step: step,
 
 		gravity:      sprec.NewVec3(0.0, -gravity, 0.0),
 		windVelocity: sprec.NewVec3(0.0, 0.0, 0.0),
@@ -29,8 +28,7 @@ func NewEngine(step time.Duration) *Engine {
 }
 
 type Engine struct {
-	step            time.Duration
-	accumulatedTime time.Duration
+	step time.Duration
 
 	gravity      sprec.Vec3
 	windVelocity sprec.Vec3
@@ -48,15 +46,19 @@ func (e *Engine) Bodies() []*Body {
 }
 
 func (e *Engine) Update(elapsedTime time.Duration) {
-	e.accumulatedTime += elapsedTime
-	for e.accumulatedTime > e.step {
-		e.accumulatedTime -= e.step
+	for elapsedTime > e.step {
 		e.runSimulation(Context{
 			ElapsedSeconds:    float32(e.step.Seconds()),
 			ImpulseIterations: impulseIterations,
 			NudgeIterations:   nudgeIterations,
 		})
+		elapsedTime -= e.step
 	}
+	e.runSimulation(Context{
+		ElapsedSeconds:    float32(elapsedTime.Seconds()),
+		ImpulseIterations: impulseIterations,
+		NudgeIterations:   nudgeIterations,
+	})
 }
 
 func (e *Engine) Add(aspect interface{}) {


### PR DESCRIPTION
## Changes

This PR makes a few changes to the physics engine in order to improve the overall experience:

* It normalizes the orientation quaternions on each iteration. This fixes a number of glitches where a body would wobble, certain constraints would fail at some point, and the body would be rendered with elongated shape.
* It does not accumulate delta times anymore. Instead it applies the whole elapsed time by first splitting it into segments that have a max duration. Most segments run at the cap duration except for the last one. Experiments show that so far this does not cause the physics (especially soft constraints) to blow up, so it should work for now. An alternative that can be applied in the future is to snapshot stable states and have one final `polished` state (based on the last time segment) which is used only for rendering. The outcome of this change is that the physics runs smoothly and in unison with other systems.