### PR TITLE
Remove unused UI concepts

### DIFF
--- a/ui/component/bootstrap.go
+++ b/ui/component/bootstrap.go
@@ -9,17 +9,9 @@ func Initialize(window *ui.Window, instance Instance) {
 
 	rootNode := createComponentNode(New(Element, func() {
 		WithData(ElementData{
-			Layout: &fillLayout{},
+			Layout: ui.NewFillLayout(),
 		})
 		WithChild("root", instance)
 	}))
-	window.SetRoot(rootNode.element)
-}
-
-type fillLayout struct{}
-
-func (l *fillLayout) Apply(element *ui.Element) {
-	for child := element.FirstChild(); child != nil; child = child.RightSibling() {
-		child.SetBounds(element.Bounds())
-	}
+	window.Root().AppendChild(rootNode.element)
 }

--- a/ui/component/element.go
+++ b/ui/component/element.go
@@ -8,13 +8,12 @@ import (
 // ElementData is the struct that should be used when configuring
 // an Element component's data.
 type ElementData struct {
-	Essence      ui.Essence
-	Enabled      optional.Bool
-	Visible      optional.Bool
-	Materialized optional.Bool
-	IdealSize    optional.Size
-	Padding      ui.Spacing
-	Layout       ui.Layout
+	Essence   ui.Essence
+	Enabled   optional.Bool
+	Visible   optional.Bool
+	IdealSize optional.Size
+	Padding   ui.Spacing
+	Layout    ui.Layout
 }
 
 // Element represents the most basic component, which is translated
@@ -40,9 +39,6 @@ var Element = Define(func(props Properties) Instance {
 	}
 	if data.Visible.Specified {
 		element.SetVisible(data.Visible.Value)
-	}
-	if data.Materialized.Specified {
-		element.SetMaterialized(data.Materialized.Value)
 	}
 	if data.IdealSize.Specified {
 		element.SetIdealSize(data.IdealSize.Value)

--- a/ui/component/store.go
+++ b/ui/component/store.go
@@ -3,6 +3,8 @@ package component
 import (
 	"fmt"
 	"reflect"
+
+	"github.com/mokiat/lacking/ui"
 )
 
 var (
@@ -259,7 +261,7 @@ var StoreProvider = Define(func(props Properties) Instance {
 
 	return New(Element, func() {
 		WithData(ElementData{
-			Layout: &fillLayout{},
+			Layout: ui.NewFillLayout(),
 		})
 		WithChildren(props.children)
 	})

--- a/ui/element.go
+++ b/ui/element.go
@@ -44,8 +44,8 @@ type Element struct {
 	parent       *Element
 	firstChild   *Element
 	lastChild    *Element
-	rightSibling *Element
 	leftSibling  *Element
+	rightSibling *Element
 
 	context *Context
 	essence Essence
@@ -53,7 +53,6 @@ type Element struct {
 	enabled bool
 	visible bool
 
-	margin       Spacing
 	padding      Spacing
 	bounds       Bounds
 	idealSize    Size
@@ -251,25 +250,6 @@ func (e *Element) InjectEssence(target interface{}) {
 		panic("cannot assign essence to specified type")
 	}
 	value.Elem().Set(reflect.ValueOf(e.essence))
-}
-
-// Margin returns the spacing that should be maintained
-// around this Element. The margin does not reflect the
-// Element's active area and is only a setting that is
-// used by layouts to further adjust the Element's position.
-func (e *Element) Margin() Spacing {
-	return e.margin
-}
-
-// SetMargin sets the amount of space that should be left
-// around the Element when positioned by a layout container.
-func (e *Element) SetMargin(margin Spacing) {
-	if margin != e.margin {
-		e.margin = margin
-		if e.parent != nil {
-			e.parent.onBoundsChanged(e.parent.bounds)
-		}
-	}
 }
 
 // Padding returns the spacing that should be maintained

--- a/ui/element.go
+++ b/ui/element.go
@@ -29,10 +29,9 @@ type ElementRenderHandler interface {
 
 func newElement(context *Context) *Element {
 	return &Element{
-		context:      context,
-		enabled:      true,
-		visible:      true,
-		materialized: true,
+		context: context,
+		enabled: true,
+		visible: true,
 	}
 }
 
@@ -51,9 +50,8 @@ type Element struct {
 	context *Context
 	essence Essence
 
-	enabled      bool
-	visible      bool
-	materialized bool
+	enabled bool
+	visible bool
 
 	margin       Spacing
 	padding      Spacing
@@ -414,29 +412,6 @@ func (e *Element) Visible() bool {
 func (e *Element) SetVisible(visible bool) {
 	if visible != e.visible {
 		e.visible = visible
-		e.invalidate()
-	}
-}
-
-// Materialized controls whether this Element is at all
-// present. If an Element is not materialized, then it is
-// not rendered, does not receive events, and is not
-// considered during layout evaluations. In essence, it is
-// almost as though it has been removed, except that it
-// is still part of the hierarchy.
-func (e *Element) Materialized() bool {
-	return e.materialized
-}
-
-// SetMaterialized specifies whether this Element should
-// be considered in any way for rendering, events and
-// layout calculations.
-func (e *Element) SetMaterialized(materialized bool) {
-	if materialized != e.materialized {
-		e.materialized = materialized
-		if e.parent != nil {
-			e.parent.onBoundsChanged(e.parent.bounds)
-		}
 		e.invalidate()
 	}
 }

--- a/ui/layout.go
+++ b/ui/layout.go
@@ -12,3 +12,21 @@ type Layout interface {
 // The actual implementation of this interface is determined by
 // the parent Element's layout model.
 type LayoutConfig interface{}
+
+// NewFillLayout returns a new FillLayout instance.
+func NewFillLayout() *FillLayout {
+	return &FillLayout{}
+}
+
+var _ Layout = (*FillLayout)(nil)
+
+// FillLayout resizes the children to fill the content space
+// of the parent element.
+type FillLayout struct{}
+
+// Apply applies this layout to the specified Element.
+func (l *FillLayout) Apply(element *Element) {
+	for child := element.FirstChild(); child != nil; child = child.RightSibling() {
+		child.SetBounds(element.Bounds())
+	}
+}

--- a/ui/mat/fill_layout.go
+++ b/ui/mat/fill_layout.go
@@ -17,10 +17,6 @@ type FillLayout struct{}
 func (l *FillLayout) Apply(element *ui.Element) {
 	contentBounds := element.ContentBounds()
 	for childElement := element.FirstChild(); childElement != nil; childElement = childElement.RightSibling() {
-		childMargin := childElement.Margin()
-		childElement.SetBounds(contentBounds.
-			Translate(ui.NewPosition(childMargin.Left, childMargin.Top)).
-			Shrink(ui.NewSize(childMargin.Horizontal(), childMargin.Vertical())),
-		)
+		childElement.SetBounds(contentBounds)
 	}
 }

--- a/ui/mat/horizontal_layout.go
+++ b/ui/mat/horizontal_layout.go
@@ -50,19 +50,19 @@ func (l *HorizontalLayout) Apply(element *ui.Element) {
 
 		switch l.contentAlignment {
 		case AlignmentTop:
-			childBounds.Y = contentBounds.Y + childElement.Margin().Top
+			childBounds.Y = contentBounds.Y
 		case AlignmentBottom:
-			childBounds.Y = contentBounds.Y + contentBounds.Height - childElement.Margin().Bottom - childBounds.Height
+			childBounds.Y = contentBounds.Y + contentBounds.Height - childBounds.Height
 		case AlignmentCenter:
 			fallthrough
 		default:
-			childBounds.Y = contentBounds.Y + (contentBounds.Height-childBounds.Height)/2 - childElement.Margin().Top
+			childBounds.Y = contentBounds.Y + (contentBounds.Height-childBounds.Height)/2
 		}
 
-		childBounds.X = leftPlacement + childElement.Margin().Left
+		childBounds.X = leftPlacement
 		childElement.SetBounds(childBounds)
 
-		leftPlacement += childElement.Margin().Horizontal() + childBounds.Width + l.contentSpacing
+		leftPlacement += childBounds.Width + l.contentSpacing
 	}
 }
 

--- a/ui/mat/vertical_layout.go
+++ b/ui/mat/vertical_layout.go
@@ -46,18 +46,18 @@ func (l *VerticalLayout) Apply(element *ui.Element) {
 
 		switch l.contentAlignment {
 		case AlignmentLeft:
-			childBounds.X = contentBounds.X + childElement.Margin().Left
+			childBounds.X = contentBounds.X
 		case AlignmentRight:
-			childBounds.X = contentBounds.X + contentBounds.Width - childElement.Margin().Right - childBounds.Width
+			childBounds.X = contentBounds.X + contentBounds.Width - childBounds.Width
 		case AlignmentCenter:
 			fallthrough
 		default:
-			childBounds.X = contentBounds.X + (contentBounds.Width-childBounds.Width)/2 - childElement.Margin().Left
+			childBounds.X = contentBounds.X + (contentBounds.Width-childBounds.Width)/2
 		}
 
-		childBounds.Y = topPlacement + childElement.Margin().Top
+		childBounds.Y = topPlacement
 		childElement.SetBounds(childBounds)
 
-		topPlacement += childElement.Margin().Vertical() + childBounds.Height + l.contentSpacing
+		topPlacement += childBounds.Height + l.contentSpacing
 	}
 }

--- a/ui/window.go
+++ b/ui/window.go
@@ -14,6 +14,8 @@ func NewWindow(appWindow app.Window, locator ResourceLocator, graphics Graphics)
 		graphics: graphics,
 	}
 	window.context = newContext(window, locator, graphics)
+	window.root = newElement(window.context)
+	window.root.SetLayout(NewFillLayout())
 	handler := &windowHandler{
 		Window: window,
 	}
@@ -81,18 +83,9 @@ func (w *Window) Context() *Context {
 	return w.context
 }
 
-// Root returns the top-most Element of this View.
+// Root returns the Element that represents this Window.
 func (w *Window) Root() *Element {
 	return w.root
-}
-
-// SetRoot changes the top-most Element of this View.
-func (w *Window) SetRoot(root *Element) {
-	if root != w.root {
-		w.pointedElement = nil
-	}
-	w.root = root
-	w.Invalidate()
 }
 
 // FindElementByID looks through the Element hierarchy tree for an Element


### PR DESCRIPTION
This PR does the following changes to the UI package:
- It removes `materialized` from the `Element` type. This was never really supported and with the new Component framework makes little sense.
- It removes `marin` from the `Element` type. The ui package does not really make use of the margin and it is not needed for the correct operation (unlike padding, which controls clipping). As such, if margins are required, they should be introduces in higher level packages (like `mat`) through LayoutConfig properties.
- It attaches a single root `Element` on the Window. This makes it easier for the Window to update root-level bounds state but also makes it easier for frameworks to create multiple overlay layers through `AppendChild` on the root Element.