### PR TITLE
Enable custom values in shaders

### DIFF
--- a/game/graphics/glsl/preset/forward.frag.glsl
+++ b/game/graphics/glsl/preset/forward.frag.glsl
@@ -10,6 +10,9 @@
 /* template "public.frag.glsl" . */
 
 smooth in float spawnTimeInOut;
+smooth in float custom0InOut;
+smooth in float custom1InOut;
+smooth in float custom2InOut;
 
 void main()
 {

--- a/game/graphics/glsl/preset/forward.vert.glsl
+++ b/game/graphics/glsl/preset/forward.vert.glsl
@@ -11,10 +11,17 @@
 /* template "public.vert.glsl" . */
 
 smooth out float spawnTimeInOut;
+smooth out float custom0InOut;
+smooth out float custom1InOut;
+smooth out float custom2InOut;
 
 void main()
 {
-  spawnTimeInOut = timeIn - timingIn[gl_InstanceID].x;
+  vec4 timing = timingIn[gl_InstanceID];
+  spawnTimeInOut = timeIn - timing.x;
+  custom0InOut = timing.y;
+  custom1InOut = timing.z;
+  custom2InOut = timing.w;
   /*- if .HasAttributeCoord */
   vec4 coord_ls = attrCoord;
   /*- else */

--- a/game/graphics/glsl/preset/geometry.frag.glsl
+++ b/game/graphics/glsl/preset/geometry.frag.glsl
@@ -10,6 +10,9 @@
 /* template "public.frag.glsl" . */
 
 smooth in float spawnTimeInOut;
+smooth in float custom0InOut;
+smooth in float custom1InOut;
+smooth in float custom2InOut;
 smooth in vec3 normalInOut;
 smooth in vec3 tangentInOut;
 smooth in vec2 texCoordInOut;

--- a/game/graphics/glsl/preset/geometry.vert.glsl
+++ b/game/graphics/glsl/preset/geometry.vert.glsl
@@ -11,6 +11,9 @@
 /* template "public.vert.glsl" . */
 
 smooth out float spawnTimeInOut;
+smooth out float custom0InOut;
+smooth out float custom1InOut;
+smooth out float custom2InOut;
 smooth out vec3 normalInOut;
 smooth out vec3 tangentInOut;
 smooth out vec2 texCoordInOut;
@@ -18,7 +21,11 @@ smooth out vec4 colorInOut;
 
 void main()
 {
-  spawnTimeInOut = timeIn - timingIn[gl_InstanceID].x;
+  vec4 timing = timingIn[gl_InstanceID];
+  spawnTimeInOut = timeIn - timing.x;
+  custom0InOut = timing.y;
+  custom1InOut = timing.z;
+  custom2InOut = timing.w;
   /*- if .HasAttributeCoord */
   vec4 coord_ls = attrCoord;
   /*- else */

--- a/game/graphics/glsl/preset/shadow.frag.glsl
+++ b/game/graphics/glsl/preset/shadow.frag.glsl
@@ -10,6 +10,9 @@
 /* template "public.frag.glsl" . */
 
 smooth in float spawnTimeInOut;
+smooth in float custom0InOut;
+smooth in float custom1InOut;
+smooth in float custom2InOut;
 
 void main()
 {

--- a/game/graphics/glsl/preset/shadow.vert.glsl
+++ b/game/graphics/glsl/preset/shadow.vert.glsl
@@ -11,10 +11,17 @@
 /* template "public.vert.glsl" . */
 
 smooth out float spawnTimeInOut;
+smooth out float custom0InOut;
+smooth out float custom1InOut;
+smooth out float custom2InOut;
 
 void main()
 {
-  spawnTimeInOut = timeIn - timingIn[gl_InstanceID].x;
+  vec4 timing = timingIn[gl_InstanceID];
+  spawnTimeInOut = timeIn - timing.x;
+  custom0InOut = timing.y;
+  custom1InOut = timing.z;
+  custom2InOut = timing.w;
   /*- if .HasAttributeCoord */
   vec4 coord_ls = attrCoord;
   /*- else */

--- a/game/graphics/glsl/translator_forward.go
+++ b/game/graphics/glsl/translator_forward.go
@@ -15,6 +15,9 @@ func (t *Translator) translateForwardVertexCode(shader *lsl.Shader, constraints 
 		// time
 		ctx.RegisterIdentifier("#time", "timeIn")
 		ctx.RegisterIdentifier("#spawnTime", "spawnTimeInOut")
+		ctx.RegisterIdentifier("#custom0", "custom0InOut")
+		ctx.RegisterIdentifier("#custom1", "custom1InOut")
+		ctx.RegisterIdentifier("#custom2", "custom2InOut")
 		// mesh
 		ctx.RegisterIdentifier("#vertexCoord", "coord_ls")
 		ctx.RegisterIdentifier("#vertexNormal", "normal_ls")
@@ -47,6 +50,9 @@ func (t *Translator) translateForwardFragmentCode(shader *lsl.Shader, constraint
 		// time
 		ctx.RegisterIdentifier("#time", "timeIn")
 		ctx.RegisterIdentifier("#spawnTime", "spawnTimeInOut")
+		ctx.RegisterIdentifier("#custom0", "custom0InOut")
+		ctx.RegisterIdentifier("#custom1", "custom1InOut")
+		ctx.RegisterIdentifier("#custom2", "custom2InOut")
 		// camera
 		ctx.RegisterIdentifier("#cameraMatrix", "cameraMatrixIn")
 		ctx.RegisterIdentifier("#viewMatrix", "viewMatrixIn")

--- a/game/graphics/glsl/translator_geometry.go
+++ b/game/graphics/glsl/translator_geometry.go
@@ -16,6 +16,9 @@ func (t *Translator) translateGeometryVertexCode(shader *lsl.Shader, constraints
 		// time
 		ctx.RegisterIdentifier("#time", "timeIn")
 		ctx.RegisterIdentifier("#spawnTime", "spawnTimeInOut")
+		ctx.RegisterIdentifier("#custom0", "custom0InOut")
+		ctx.RegisterIdentifier("#custom1", "custom1InOut")
+		ctx.RegisterIdentifier("#custom2", "custom2InOut")
 		// mesh
 		ctx.RegisterIdentifier("#vertexCoord", "coord_ls")
 		ctx.RegisterIdentifier("#vertexNormal", "normal_ls")
@@ -52,6 +55,9 @@ func (t *Translator) translateGeometryFragmentCode(shader *lsl.Shader, constrain
 		// time
 		ctx.RegisterIdentifier("#time", "timeIn")
 		ctx.RegisterIdentifier("#spawnTime", "spawnTimeInOut")
+		ctx.RegisterIdentifier("#custom0", "custom0InOut")
+		ctx.RegisterIdentifier("#custom1", "custom1InOut")
+		ctx.RegisterIdentifier("#custom2", "custom2InOut")
 		// camera
 		ctx.RegisterIdentifier("#cameraMatrix", "cameraMatrixIn")
 		ctx.RegisterIdentifier("#viewMatrix", "viewMatrixIn")

--- a/game/graphics/glsl/translator_shadow.go
+++ b/game/graphics/glsl/translator_shadow.go
@@ -15,6 +15,9 @@ func (t *Translator) translateShadowVertexCode(shader *lsl.Shader, constraints g
 		// time
 		ctx.RegisterIdentifier("#time", "timeIn")
 		ctx.RegisterIdentifier("#spawnTime", "spawnTimeInOut")
+		ctx.RegisterIdentifier("#custom0", "custom0InOut")
+		ctx.RegisterIdentifier("#custom1", "custom1InOut")
+		ctx.RegisterIdentifier("#custom2", "custom2InOut")
 		// mesh
 		ctx.RegisterIdentifier("#vertexCoord", "coord_ls")
 		ctx.RegisterIdentifier("#vertexNormal", "normal_ls")
@@ -47,6 +50,9 @@ func (t *Translator) translateShadowFragmentCode(shader *lsl.Shader, constraints
 		// time
 		ctx.RegisterIdentifier("#time", "timeIn")
 		ctx.RegisterIdentifier("#spawnTime", "spawnTimeInOut")
+		ctx.RegisterIdentifier("#custom0", "custom0InOut")
+		ctx.RegisterIdentifier("#custom1", "custom1InOut")
+		ctx.RegisterIdentifier("#custom2", "custom2InOut")
 		// camera
 		ctx.RegisterIdentifier("#cameraMatrix", "cameraMatrixIn")
 		ctx.RegisterIdentifier("#viewMatrix", "viewMatrixIn")

--- a/game/graphics/mesh.go
+++ b/game/graphics/mesh.go
@@ -26,6 +26,9 @@ func newMesh(scene *Scene, info MeshInfo) *Mesh {
 	mesh.maxCascade = definition.geometry.maxCascade
 	mesh.armature = info.Armature
 	mesh.active = true
+	mesh.SetCustom0Value(0.0)
+	mesh.SetCustom1Value(0.0)
+	mesh.SetCustom2Value(0.0)
 	mesh.setSpawnTime(scene.gameTime)
 	return mesh
 }
@@ -59,6 +62,21 @@ func (m *Mesh) SetMatrix(matrix dprec.Mat4) {
 	position := matrix.Translation()
 	radius := m.definition.geometry.boundingSphereRadius
 	m.scene.dynamicMeshSet.Update(m.itemID, position, radius)
+}
+
+func (m *Mesh) SetCustom0Value(value float32) {
+	block := gblob.LittleEndianBlock(m.instanceData[:])
+	block.SetFloat32(1*4, value)
+}
+
+func (m *Mesh) SetCustom1Value(value float32) {
+	block := gblob.LittleEndianBlock(m.instanceData[:])
+	block.SetFloat32(2*4, value)
+}
+
+func (m *Mesh) SetCustom2Value(value float32) {
+	block := gblob.LittleEndianBlock(m.instanceData[:])
+	block.SetFloat32(3*4, value)
 }
 
 func (m *Mesh) setSpawnTime(spawnTime time.Duration) {
@@ -102,6 +120,9 @@ func createStaticMesh(scene *Scene, info StaticMeshInfo) {
 	staticMesh.matrixData = make([]byte, 16*4)
 	staticMesh.armature = info.Armature
 	staticMesh.active = true
+	staticMesh.SetCustom0Value(0.0)
+	staticMesh.SetCustom1Value(0.0)
+	staticMesh.SetCustom2Value(0.0)
 	staticMesh.setSpawnTime(scene.gameTime)
 
 	matrix := dtos.Mat4(info.Matrix)
@@ -131,6 +152,21 @@ func (m *StaticMesh) SetActive(active bool) {
 		m.setSpawnTime(m.scene.gameTime)
 		m.active = active
 	}
+}
+
+func (m *StaticMesh) SetCustom0Value(value float32) {
+	block := gblob.LittleEndianBlock(m.instanceData[:])
+	block.SetFloat32(1*4, value)
+}
+
+func (m *StaticMesh) SetCustom1Value(value float32) {
+	block := gblob.LittleEndianBlock(m.instanceData[:])
+	block.SetFloat32(2*4, value)
+}
+
+func (m *StaticMesh) SetCustom2Value(value float32) {
+	block := gblob.LittleEndianBlock(m.instanceData[:])
+	block.SetFloat32(3*4, value)
 }
 
 func (m *StaticMesh) setSpawnTime(spawnTime time.Duration) {


### PR DESCRIPTION
## Changes

- Allows for up to 3 custom float32 values to be assigned on a mesh and consumed from the shader
